### PR TITLE
Ex. 1: Add new client in Docker Compose

### DIFF
--- a/TP0/docker-compose-dev.yaml
+++ b/TP0/docker-compose-dev.yaml
@@ -26,6 +26,17 @@ services:
     depends_on:
       - server
 
+  client2:
+    container_name: client2
+    image: client:latest
+    entrypoint: /client
+    environment:
+      - CLI_ID=2
+    networks:
+      - testing_net
+    depends_on:
+      - server
+
 networks:
   testing_net:
     ipam:


### PR DESCRIPTION
# Summary

Add definition for new client in Docker Compose, using default config defined in `./client/config.yaml` instead of repeating environment variables.

## Linked issues

Resolves #2
