### PR TITLE
Add missing metadata on package

### DIFF
--- a/packages/example_package/Cargo.toml
+++ b/packages/example_package/Cargo.toml
@@ -2,6 +2,8 @@
 name = "distribuidos_example_package"
 version = "0.0.0"
 edition = "2021"
+license = "MIT"
+description = "Example package"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Summary

Add `description` and `license` missing metadata.
