### PR TITLE
Run lint only for Rust files

### DIFF
--- a/.github/workflows/tp1_ci.yaml
+++ b/.github/workflows/tp1_ci.yaml
@@ -3,7 +3,7 @@ name: TP1 CI
 on:
   push:
     paths:
-      - TP1/**/*
+      - TP1/**/*.rs
 
 jobs:
   lint:


### PR DESCRIPTION
# Summary

Run lint only for Rust files.
